### PR TITLE
Fix clickEvent being put on wrong element for tables

### DIFF
--- a/sources/index.js
+++ b/sources/index.js
@@ -100,6 +100,11 @@ export default class ShowMore {
           addRemoveClass(items[i], true);
         }
 
+        if (!nobutton) {
+        // add button to the list and table
+          this._addBtn(this._object);
+        }
+
         // add event click
         this._clickEvent(
           type === "list" ? element : element.nextElementSibling,
@@ -107,8 +112,6 @@ export default class ShowMore {
         );
 
         if (nobutton) return;
-        // add button to the list and table
-        this._addBtn(this._object);
       }
     }
   };


### PR DESCRIPTION
Currently, code for adding the clickEvent when used with a button
for a table results in the clickEvent being put on the
nextElementSibling of the table. This could be null or an unrelated
element.

This fix moves the button creation to before the registration of the
clickEvent, ensuring that the button is always the nextElementSibling.

fixes https://github.com/tomik23/show-more/issues/52